### PR TITLE
2 player mode bug fix, made 4-color deck display, simplify input

### DIFF
--- a/display.py
+++ b/display.py
@@ -121,7 +121,7 @@ def show_player_stats(initial_players, isShowDown=False):
                     chips = f'             Chips:{this_player.chips:>6}'
                 print_msg = f"{this_player.name:>11}'s hand:    {hand_str}{chips}{bet}"
                 if this_player.isDealer:
-                    print_msg += f'       <Button>'
+                    print_msg += f'       <Dealer>'
                 if this_player.isSB:
                     print_msg += f'       <SB>'
                 if this_player.isBB:

--- a/display.py
+++ b/display.py
@@ -121,7 +121,11 @@ def show_player_stats(initial_players, isShowDown=False):
                     chips = f'             Chips:{this_player.chips:>6}'
                 print_msg = f"{this_player.name:>11}'s hand:    {hand_str}{chips}{bet}"
                 if this_player.isDealer:
-                    print_msg += f'       <Dealer>'
+                    print_msg += f'       <Button>'
+                if this_player.isSB:
+                    print_msg += f'       <SB>'
+                if this_player.isBB:
+                    print_msg += f'       <BB>'
         else:
             print_msg = f"{this_player.name:>18}:    [OUT OF CHIPS, OUT OF GAME]"
         print(print_msg)


### PR DESCRIPTION

In 2 player poker, [the dealer is small blind and should act first pre-flop](https://www.telegraph.co.uk/betting/casino-guides/poker/what-is-heads-up-poker-how-to-play/), in the original code this is backwards -- the dealer is big blind and acts second pre-flop.

You can see here in the original code the dealer is the BB and the first action is given to the user:

![image](https://user-images.githubusercontent.com/6371270/105530584-d7328d00-5c9c-11eb-8b32-d35f297dc8cf.png)

In the updated code, the dealer is SB and was given first action (in this case the dealer chose to raise before action was passed to the user). 

![image](https://user-images.githubusercontent.com/6371270/105530732-06e19500-5c9d-11eb-9fe5-a0c3e43fa06a.png)

Some other quality of life updates I added:

- Input is just done by keypress (c/f/r) without having to press enter
- Added colors to depict a [4 color deck](https://en.wikipedia.org/wiki/Four-color_deck)
- SB and BB are marked in the player list

![image](https://user-images.githubusercontent.com/6371270/105532513-c899a500-5c9f-11eb-9912-b1b67e8ec570.png)
